### PR TITLE
Refs #28325 - Make the plugin show some information in the UI also if coordinates are not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ This is an example app which implements a Google Maps plugin on the item page, p
 
 ## Installation
 
-To install this plugin, just place the entire directory under `/opt/cantemo/portal/portal/plugins`.
+To install this plugin, place the entire directory under `/opt/cantemo/portal/portal/plugins/`.
 
 Make sure the directory is readable by the Portal web-workers (default `www-data`).
 
-For example, on a Portal system:
+For example, on a Portal system run these commands:
 
 ```
 curl -L https://github.com/Cantemo/PortalGoogleMapsPlugin/archive/master.zip > PortalGoogleMapsPlugin-master.zip 
@@ -24,3 +24,5 @@ This plugin hooks into the MediaViewLeftContentBottom plugin block and
 displays a google map in an iframe in the lower left hand corner of
 the item page, based on the EXIF GPS coordinates embedded in a photo.
 
+Please note that "Parse XMP" must be enabled in System Settings > Metadata Indexing when the
+file is ingested, otherwise all XMP data will be ignored.

--- a/templates/maps/google_map.html
+++ b/templates/maps/google_map.html
@@ -4,4 +4,8 @@
 
 <iframe width="200" height="200" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://maps.google.se/?q={{ coords }}&amp;ll={{ coords }}&amp;t=m&amp;ie=UTF8&amp;&amp;z=12&amp;mrt=loc&amp;iwloc=&amp;output=embed&amp;sll=0,0"></iframe><br /><small><a href="http://maps.google.se/?q={{ coords }}&amp;t=m&amp;ie=UTF8&amp;ll={{ coords }}&amp;spn=0.140157,0.413361&amp;z=12&amp;source=embed" style="color:#4390bc;text-align:left">{% trans "Show larger map" %}</a></small>
 
+{% elif error_message %}
+
+<p>Maps plugin: {{ error_message }}</p>
+
 {% endif %}


### PR DESCRIPTION
... or if there is an error parsing them. This makes it much easier to debug whether the plugin is enabled or if the item does not have the required metadata.

Also formatted the source with  `black`, and clarified instructions regarding "Parse XMP" setting.